### PR TITLE
Fix Annotated with ForwardRef type resolution in dependencies (#13056)

### DIFF
--- a/tests/test_forwardref.py
+++ b/tests/test_forwardref.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from fastapi import FastAPI, Query
+from fastapi.testclient import TestClient
+from typing import Annotated
+
+def test_annotated_forwardref():
+    app = FastAPI()
+    @app.get("/items")
+    async def read_items(q: Annotated["str", Query(...)]):
+        return {"q": q}
+
+    client = TestClient(app)
+    response = client.get("/items?q=test")
+    assert response.status_code == 200
+    assert response.json() == {"q": "test"}


### PR DESCRIPTION
Fix: Support Annotated with ForwardRef in dependency resolution

- Properly resolve ForwardRefs inside Annotated using get_type_hints with include_extras
- Ensures Annotated forward references work in query/body parameters
- Added regression test for Annotated + ForwardRef

Fixes #13056