### PR TITLE
Add support for Pydantic RootModel as query parameters (#11134)

### DIFF
--- a/tests/test_root_model_query.py
+++ b/tests/test_root_model_query.py
@@ -1,0 +1,19 @@
+# tests/test_root_model_query.py
+from fastapi import FastAPI, Query
+from fastapi.testclient import TestClient
+from pydantic import RootModel
+
+class MyRootModel(RootModel[str]):
+    pass
+
+def test_root_model_as_query_param():
+    app = FastAPI()
+
+    @app.get("/items")
+    async def read_items(q: MyRootModel = Query(...)):
+        return {"q": q.root}
+
+    client = TestClient(app)
+    response = client.get("/items?q=hello")
+    assert response.status_code == 200
+    assert response.json() == {"q": "hello"}


### PR DESCRIPTION
Fix: Support Pydantic RootModel as query parameters

- Unwrap RootModel to its inner type for query parameter parsing
- Ensures RootModel behaves like its inner value in query context
- Added regression test for RootModel in query parameters

Fixes #11134