### PR TITLE
Add support for HTTP QUERY method via app.query() (#12965)

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1052,6 +1052,8 @@ class FastAPI(Starlette):
         if self.root_path:
             scope["root_path"] = self.root_path
         await super().__call__(scope, receive, send)
+    def query(self, path: str, **kwargs):
+    return self.api_route(path, methods=["QUERY"], **kwargs)
 
     def add_api_route(
         self,


### PR DESCRIPTION
Add support for HTTP QUERY method via `app.query()` (#12965)

- Added `FastAPI.query()` helper in `applications.py` similar to `.get()`, `.post()`, etc.
- Enables developers to register routes for the non-standard HTTP `QUERY` method using:
  
    @app.query("/path")
    async def handle_query():
        return {"message": "Handled QUERY"}
        
- Uses `api_route()` internally with `methods=["QUERY"]`.

Note: Requires running Uvicorn with `--http h11` or another ASGI server that accepts custom HTTP methods, as `httptools` does not support QUERY by default.