### PR TITLE
Add support for HTTP QUERY method via app.query() (#12965)

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -1052,6 +1052,11 @@ class FastAPI(Starlette):
         if self.root_path:
             scope["root_path"] = self.root_path
         await super().__call__(scope, receive, send)
+    def query(self, path: str, **kwargs):
+    """
+    Add a route that handles the HTTP QUERY method.
+    """
+    return self.api_route(path, methods=["QUERY"], **kwargs)
 
     def add_api_route(
         self,


### PR DESCRIPTION
- Added FastAPI.query() helper in applications.py, similar to app.get() and app.post().
- Enables developers to register routes for the non-standard HTTP QUERY method using a simple decorator.
- Note: Requires running Uvicorn with the h11 HTTP parser since httptools rejects unknown methods.